### PR TITLE
v0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Manuca works by utilizing [chemparse](https://pypi.org/project/chemparse/) to ev
 
 #### Output
 
-Manuca v0.1 calculates the following outputs:
+Manuca version 0.14 calculates the following outputs:
 
 - Composition in atomic % (at.%) and weight % (wt.%)
 
@@ -101,17 +101,21 @@ Manuca v0.1 calculates the following outputs:
   - Everhart (1960):
     
     $\overline{Z}=\sum_i c_i Z^2_i/\sum_i c_i Z_i$
-    
-  - [Donovan](https://doi.org/10.1017/S1431927603030137) (2003, with x = 0.8):
   
+  - [Donovan](https://doi.org/10.1017/S1431927603030137) (2003, with x = 0.8):
+    
     $\overline{Z}=\sum_i a_i Z^{1.8}_i/\sum_i a_i Z_i^{0.8}$
   
-*    Other properties:
-  
-  * Egerton (effective Z for EFTEM):
+  - Langmore (effective $Z$ for *elastic* scattering) (see also [Zhang et al.](https://doi.org/10.1016/j.ultramic.2016.09.005), and [Basha et al.](https://doi.org/10.1016/j.ultramic.2022.113570))
     
-    $\overline{Z}_\text{eff}=\sum_i a_i Z^{1.3}_i/\sum_i a_i Z^{0.3}_i$
+    $\overline{Z}_\text{eff,el}=\left(\sum_i a_i Z^{3/2}_i\right)^{2/3}$
     
-    Eq. (5.4) from Egerton, R. F. *Electron Energy-Loss Spectroscopy in the Electron Microscope*. (Springer US, 2011). doi:[10.1007/978-1-4419-9583-4](https://doi.org/10.1007/978-1-4419-9583-4).
+    Langmore et al. *Collection of scattered electrons in dark field electron -microscopy. 1. Elastic-scattering* Optik, 38 (1973), pp. 335-350
   
-  * Total and average atomic mass/molecular weight in g/mol.
+  - Egerton (effective $Z$, and $A$ in g/mol for *inelastic* scattering for EELS/EFTEM):
+    
+    $\overline{Z}_\text{eff,inel}=\sum_i a_i Z^{1.3}_i/\sum_i a_i Z^{0.3}_i$
+    $\overline{A}_\text{eff,inel}=\sum_i a_i A^{1.3}_i/\sum_i a_i A^{0.3}_i$
+    
+    Eq. (5.4) from Egerton, R. F. *Electron Energy-Loss Spectroscopy in the Electron      Microscope*. (Springer US, 2011). doi:[10.1007/978-1-4419-9583-4](https://doi.org/10.1007/978-1-4419-9583-4).
+* Total and average atomic mass/molecular weight in g/mol.

--- a/manuca.py
+++ b/manuca.py
@@ -2,8 +2,8 @@ import numpy as np #https://numpy.org/
 import chemparse #https://pypi.org/project/chemparse/
 from mendeleev import element #https://github.com/lmmentel/mendeleev
 
-version = 0.13
-date = "08/2022"
+version = 0.14
+date = "09/2022"
 
 def printHelp():
     '''Print the help dialog'''
@@ -22,9 +22,10 @@ def printHelp():
     print('    "Joyet (1954) -> Buechner, Bestimmung der mittleren Ordnungszahl vonLegierungen bei der quantitativen Mikrosondenanalyse, Arch Eisenhüttenwesen 44 (1973), Source: https://doi.org/10.1002/sca.1998.4950200105')
     print('    "Everhart (1960) -> Everhart, Simple theory concerning the reflection of electrons from solids. J Appl Phys 31 (1960), https://doi.org/10.1063/1.1735868')
     print('    "Donovan (2003) -> Donovan, J., Pingitore, N., & Westphal, A. (2003). Compositional Averaging of Backscatter Intensities in Compounds. Microscopy and Microanalysis, 9(3), 202-215. https://doi.org/10.1017/S1431927603030137')
+    print('    "Zeff (el, Langmore)" -> Effective atomic number for elastic scattering. Langmore et al. Optik, 38 (1973), pp. 335-350')
+    print('    "Zeff (inel, Egerton)" -> Effective atomic number for inelastic scattering. Eq. (5.4) from Egerton, Electron Energy-Loss Spectroscopy in the Electron Microscope, Springer (2011)')
     print('  "Other properties" -> Other compound properties which can be calculated from the stoichiometry.')
-    print('    "Zeff (Egerton, EFTEM)" -> Eq. (5.4) from Egerton, Electron Energy-Loss Spectroscopy in the Electron Microscope, Springer (2011)')
-    print('    "Aeff (Egerton, EFTEM)" -> Effective atomic mass for EFTEM.')
+    print('    "Aeff (inel, Egerton)" -> Effective atomic mass for inelastic scattering in g/mol.')
     print('    "Tot. at. mass" -> Total atomic/molecular mass in g/mol.')
     print('    "Avg. at. mass" -> Average atomic/molecular mass in g/mol.')
     print('\nUsing "multi" to construct multi-compound samples:')
@@ -36,33 +37,33 @@ def printHelp():
     print(f'Manuca version: {version}, {date}, Author: Lukas Gruenewald')
     print(f'Github: https://github.com/lukmuk/manuca')
     print('==============================================')
-    
+
 def multi_compound(n_comp):
     '''Create multi-compound from n_comp compounds'''
     #mc stores compounds
     mc_in = np.zeros(n_comp, dtype=[('comp', 'U500'),('conc', 'f4')])
-    
+
     #Grab and store sub-compound strings and relative concentrations from user input
     for i in range(n_comp):
-            print(f'Compound {i+1} of {n_comp}.') 
+            print(f'Compound {i+1} of {n_comp}.')
             comp = input('Enter stoichiometry: ')
             rel_conc = input('Enter relative concentration: ')
             mc_in[i] = (comp, rel_conc)
-            
-    #Total concentration for normalization 
+
+    #Total concentration for normalization
     mc_in['conc'] /= np.sum(mc_in['conc'])
-    
+
     #Initialize Complete string
     S = ''
-    
+
     #Parse each compound, weight with normalized concentration factor, and append to S
     for i, c in enumerate(mc_in['comp']):
         d = chemparse.parse_formula(c)
-        
+
         #Normalize each compound, not useful?
         #d_sum = sum(d.values())
         #d.update((x, np.round(y/d_sum,4)) for x, y in d.items())
-        
+
         #Weight with user input
         d.update((x, np.round(y*mc_in['conc'][i],4)) for x, y in d.items())
         for ele, r in d.items():
@@ -83,20 +84,20 @@ while True:
     if(user_input == 'multi'):
         n_comp = int(input("Enter number of compounds: "))
         multicompound = multi_compound(n_comp)
-    
+
     # Dictionary from chemparse with values
     if(user_input == 'multi'):
         parse = multicompound
     else:
         parse = user_input
-    
+
     ### Calculations
     d = chemparse.parse_formula(parse)
     e = list(d.keys()) #elements
     w = np.array(list(d.values())) #weights
     try:
         m = element(e) #Element properties from mendeleev
-    except: 
+    except:
         print('At least one element could not be recognized. Please check stoichiometry and try again.')
         continue
 
@@ -114,23 +115,24 @@ while True:
     Z = np.array([element.atomic_number for element in m])
     Wtpercents = np.fromiter(d_wtp.values(), dtype='float')
     Atpercents = np.fromiter(d_atp.values(), dtype='float')
-    
+
     meanZ_Average = np.round(np.sum(w/n*Z), decimals) #Simple average based on atomic proportions
     meanZ_Mueller = np.round(np.sum(Z*Wtpercents), decimals) #Mueller 1954
     meanZ_SaldickAllen = np.round(np.sum(Atpercents*Z**2)/np.sum(Atpercents*Z), decimals) #Saldick and Allen 1954
-    meanZ_Joyet = np.round(np.sqrt(np.sum(Atpercents*Z**2)), decimals) #Joyet 1953, Hohn und Niedrig 1972, Büchner 1973 
+    meanZ_Joyet = np.round(np.sqrt(np.sum(Atpercents*Z**2)), decimals) #Joyet 1953, Hohn und Niedrig 1972, Büchner 1973
     meanZ_Everhart = np.round(np.sum(Wtpercents*Z**2)/np.sum(Wtpercents*Z), decimals) #Everhart 1960, Joy 1995
     meanZ_Donovan = np.round(np.sum(Atpercents*Z**1.8)/np.sum(Atpercents*Z**0.8), decimals) #Donovan, 2003, x=0.8
-    
+
     ### Effective atomic number
-    Zeff_Egerton = np.round(np.sum(Atpercents*Z**1.3)/np.sum(Atpercents*Z**0.3), decimals) #effective Z, Egerton for EFTEM
-    Aeff_Egerton = np.round(np.sum(Atpercents*aw**1.3)/np.sum(Atpercents*aw**0.3), decimals) #effective A, Egerton for EFTEM
-    
+    Zeff_Langmore = np.round(np.power(np.sum(Atpercents*Z**1.5), 2/3) , decimals) # effective Z for elastic scattering, Langmore, J.P. and Wall, J. and Isaacson, M.S., Optik 38 1973
+    Zeff_Egerton = np.round(np.sum(Atpercents*Z**1.3)/np.sum(Atpercents*Z**0.3), decimals) #effective Z for inelastic scattering, Egerton for EFTEM
+    Aeff_Egerton = np.round(np.sum(Atpercents*aw**1.3)/np.sum(Atpercents*aw**0.3), decimals) #effective A or inelastic scattering, Egerton for EFTEM
+
     ### Atomic mass
     tot_atomic_mass = np.round(np.sum(w*aw), decimals)
     avg_atomic_mass = np.round(np.sum(w/n*aw), decimals)
-    
-    #Print results
+
+    ### Print results
     print('Chemical formula:')
     print(chemparse.parse_formula(parse))
     print('------------------------------')
@@ -147,13 +149,11 @@ while True:
     print(f'Everhart (1960):\t{meanZ_Everhart}')
     print(f'Donovan (2003):\t\t{meanZ_Donovan}')
     print('------------------------------')
-    print('Other properties:')
+    print(f'Zeff (el, Langmore):\t{Zeff_Langmore}')
+    print(f'Zeff (inel, Egerton):\t{Zeff_Egerton}')
     print('------------------------------')
-    print(f'Zeff (Egerton, EFTEM):\t{Zeff_Egerton}')
-    print(f'Aeff (EFTEM, g/mol):\t{Aeff_Egerton}')
+    print('Other properties:')
+    print(f'Aeff (inel, Egerton):\t{Aeff_Egerton}')
     print(f'Tot. A (g/mol):\t\t{tot_atomic_mass}')
     print(f'Avg. A (g/mol):\t\t{avg_atomic_mass}')
     print('==============================\n')
-    
-
-    


### PR DESCRIPTION
Changes in v0.14:

- Re-arranged printed output to seperate mean/effective Z and atomic masses A.
- Added formula for elastic scattering from Langmore et al., which I actually took from [https://doi.org/10.1016/j.ultramic.2022.113570](https://doi.org/10.1016/j.ultramic.2022.113570) and [https://doi.org/10.1016/j.ultramic.2016.09.005](https://doi.org/10.1016/j.ultramic.2016.09.005).
